### PR TITLE
LMDscandatacfg telegram formatting fix

### DIFF
--- a/LMS1xx.cpp
+++ b/LMS1xx.cpp
@@ -170,10 +170,10 @@ void LMS1xx::setScanCfg(const scanCfg &cfg) {
 
 void LMS1xx::setScanDataCfg(const scanDataCfg &cfg) {
 	char buf[100];
-	sprintf(buf, "%c%s %X 00 %d %d 0 %X 0 0 %d 0 %d +%d%c", 0x02,
+	sprintf(buf, "%c%s %02X 00 %d %d 0 %02X 00 %d %d 0 %d +%d%c", 0x02,
 			"sWN LMDscandatacfg", cfg.outputChannel, cfg.remission ? 1 : 0,
 			cfg.resolution, cfg.encoder, cfg.position ? 1 : 0,
-			cfg.deviceName ? 1 : 0, cfg.outputInterval, 0x03);
+			cfg.deviceName ? 1 : 0, cfg.timestamp ? 1 : 0, cfg.outputInterval, 0x03);
 	if(debug)
 		printf("%s\n", buf);
 	write(sockDesc, buf, strlen(buf));

--- a/LMS1xx.h
+++ b/LMS1xx.h
@@ -102,6 +102,8 @@ typedef struct _scanDataCfg {
 	 * Determines whether the device name is to be output.
 	 */
 	bool deviceName;
+	
+	bool timestamp;
 
 	/*!
 	 * @brief Output interval.


### PR DESCRIPTION
The sWN LMDscandatacfg telegram was fixed according to lms1xx and lms5xx
developers guide v3.6
(http://www.sickcn.com/media/89813/developers_guide_lms1xx_5xx_v3.6.pdf).
